### PR TITLE
fix: Add MinGW target flag for clang on Windows in build-llvm mode

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -14,6 +14,7 @@ import System.Directory (doesFileExist, getCurrentDirectory, removeFile, createD
 import System.Environment (getArgs)
 import System.Exit (exitFailure, exitSuccess, ExitCode(..))
 import System.FilePath (takeDirectory, takeBaseName, replaceExtension)
+import System.Info (os)
 import System.Process (readProcessWithExitCode)
 import Spinor.Syntax    (Expr(..), readExpr, parseFile, formatError, SpinorError(..), dummySpan)
 import Spinor.Type      (TypeEnv, showType)
@@ -362,8 +363,10 @@ buildLlvmMode quiet file = do
 
           -- 5. clang でコンパイル
           clangPath <- findClang
+          let targetFlags = if os == "mingw32" then ["--target=x86_64-pc-windows-gnu"] else []
+              clangArgs = targetFlags ++ ["-o", outFile, llFile, runtimeSrc]
           when (not quiet) $ putStrLn $ "Building " <> outFile <> " with " <> clangPath <> "..."
-          (exitCode, out, err) <- readProcessWithExitCode clangPath ["-o", outFile, llFile, runtimeSrc] ""
+          (exitCode, out, err) <- readProcessWithExitCode clangPath clangArgs ""
           case exitCode of
             ExitSuccess -> do
               -- 6. クリーンアップと完了メッセージ


### PR DESCRIPTION
## Summary
- Windows 上で `build-llvm` モード実行時、clang が MSVC ヘッダー (`stdio.h`) を見つけられずビルドに失敗する問題を修正
- clang 呼び出し時に `--target=x86_64-pc-windows-gnu` フラグを付与し、MinGW (MSYS2) のヘッダーを使用するように変更

## Test plan
- [x] `cabal build` が成功することを確認
- [x] `cabal run spinor -- build-llvm fib-aot.spin` が正常にコンパイルされることを確認
- [x] 生成された `fib-aot.exe` が正しい結果 (`55`) を出力することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)