### PR TITLE
fix: Windows WASM build and C codegen issues

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -11,11 +11,12 @@ import Data.Aeson (object, (.=), encode)
 import System.IO (hFlush, stdout, hSetBuffering, BufferMode(..), stdin, hIsEOF, hSetEncoding, utf8)
 import Control.Monad (when)
 import System.Directory (doesFileExist, getCurrentDirectory, removeFile, createDirectoryIfMissing)
-import System.Environment (getArgs)
+import System.Environment (getArgs, getEnvironment)
 import System.Exit (exitFailure, exitSuccess, ExitCode(..))
 import System.FilePath (takeDirectory, takeBaseName, replaceExtension)
 import System.Info (os)
-import System.Process (readProcessWithExitCode)
+import System.Process (readProcessWithExitCode, readCreateProcessWithExitCode, proc)
+import qualified System.Process as Proc
 import Spinor.Syntax    (Expr(..), readExpr, parseFile, formatError, SpinorError(..), dummySpan)
 import Spinor.Type      (TypeEnv, showType)
 import Spinor.Val       (Env)
@@ -480,7 +481,7 @@ buildWasmMode quiet file = do
                       , cFile
                       , runtimeSrc
                       ]
-      (exitCode, out, err) <- readProcessWithExitCode emccPath emccFlags ""
+      (exitCode, out, err) <- runEmcc emccPath emccFlags
       case exitCode of
         ExitSuccess -> do
           -- 4. クリーンアップと完了メッセージ
@@ -498,10 +499,14 @@ buildWasmMode quiet file = do
 findEmcc :: IO FilePath
 findEmcc = do
     let candidates =
-          [ "emcc"  -- PATH にあればこれを使う
-          , "/usr/lib/emscripten/emcc"
-          , "/usr/local/bin/emcc"
-          ]
+          if os == "mingw32"
+          then [ "emcc"
+               , "C:\\emsdk\\upstream\\emscripten\\emcc.bat"
+               ]
+          else [ "emcc"
+               , "/usr/lib/emscripten/emcc"
+               , "/usr/local/bin/emcc"
+               ]
     findFirst candidates
   where
     findFirst [] = do
@@ -510,6 +515,25 @@ findEmcc = do
     findFirst (c:cs) = do
       exists <- doesFileExist c
       if exists then pure c else findFirst cs
+
+-- | emcc を実行する
+--   Windows では EMSDK_PYTHON 環境変数を設定して、emcc.bat の
+--   サブプロセスが正しい Python を使えるようにする。
+runEmcc :: FilePath -> [String] -> IO (ExitCode, String, String)
+runEmcc emccPath args
+  | os == "mingw32" = do
+      let emsdkPython = "C:\\emsdk\\python\\3.13.3_64bit\\python.exe"
+      pyExists <- doesFileExist emsdkPython
+      if pyExists
+        then do
+          baseEnv <- getEnvironment
+          let env' = ("EMSDK_PYTHON", emsdkPython)
+                   : ("EMSDK", "C:/emsdk")
+                   : filter (\(k,_) -> k /= "EMSDK_PYTHON" && k /= "EMSDK") baseEnv
+              cp = (proc emccPath args) { Proc.env = Just env' }
+          readCreateProcessWithExitCode cp ""
+        else readProcessWithExitCode emccPath args ""
+  | otherwise = readProcessWithExitCode emccPath args ""
 
 -- | 起動時に Twister ファイルをロードする
 --   各式を展開 → 型推論 (ベストエフォート) → 評価し、

--- a/src/Spinor/Compiler/Codegen.hs
+++ b/src/Spinor/Compiler/Codegen.hs
@@ -26,6 +26,22 @@ import Spinor.EscapeAnalysis (EscapeResult(..))
 -- | C コードの型エイリアス
 type CCode = Text
 
+-- | AST 中に OpenGL 関連のシンボル (gl-*) が含まれるか検査する
+usesGL :: [Expr] -> Bool
+usesGL = any exprUsesGL
+  where
+    glSymbols :: [Text]
+    glSymbols = ["gl-init", "gl-clear", "gl-draw-points",
+                 "gl-swap-buffers", "gl-window-should-close"]
+    exprUsesGL :: Expr -> Bool
+    exprUsesGL (ESym _ s) = s `elem` glSymbols
+    exprUsesGL (EList _ xs) = any exprUsesGL xs
+    exprUsesGL (ELet _ binds body) =
+      any (exprUsesGL . snd) binds || exprUsesGL body
+    exprUsesGL (EWithRegion _ _ body) = exprUsesGL body
+    exprUsesGL (EAllocIn _ _ body) = exprUsesGL body
+    exprUsesGL _ = False
+
 -- | プログラム全体を C 言語のソースコードに変換する
 --
 -- defun 式は C のトップレベル関数に変換され、
@@ -35,13 +51,15 @@ compileProgram exprs =
     let (defuns, others) = partition isDefun exprs
         funDefs = T.unlines (map compileFunDef defuns)
         mainStmts = T.unlines (map compileStmt others)
+        glCode = if usesGL exprs
+                 then T.unlines [glIncludes, glHelpers]
+                 else ""
     in T.unlines
         [ "#include <stdio.h>"
         , "#include <stdbool.h>"
         , "#include \"spinor.h\""
         , ""
-        , glIncludes
-        , glHelpers
+        , glCode
         , funDefs
         , "int main(void) {"
         , mainStmts
@@ -58,14 +76,16 @@ compileProgramWithOwnership exprs borrowResult =
         funDefs = T.unlines (map compileFunDef defuns)
         mainStmts = T.unlines (map compileStmt others)
         freeStmts = generateFreeStatements (brDropPoints borrowResult)
+        glCode = if usesGL exprs
+                 then T.unlines [glIncludes, glHelpers]
+                 else ""
     in T.unlines
         [ "#include <stdio.h>"
         , "#include <stdlib.h>  /* for free() - ownership system */"
         , "#include <stdbool.h>"
         , "#include \"spinor.h\""
         , ""
-        , glIncludes
-        , glHelpers
+        , glCode
         , funDefs
         , "int main(void) {"
         , mainStmts
@@ -102,8 +122,9 @@ compileProgramWithRegions exprs _escapeResult =
         , ""
         , arenaAllocatorCode
         , ""
-        , glIncludes
-        , glHelpers
+        , if usesGL exprs
+          then T.unlines [glIncludes, glHelpers]
+          else ""
         , funDefs
         , "int main(void) {"
         , mainStmts
@@ -205,7 +226,7 @@ arenaAllocatorCode = T.unlines
     , "        if (str) {"
     , "            memcpy(str, s, len);"
     , "            obj->type = SP_STR;"
-    , "            obj->value.str = str;"
+    , "            obj->value.string = str;"
     , "        }"
     , "    }"
     , "    return obj;"
@@ -447,14 +468,14 @@ glHelpers = T.unlines
     , "SpObject* sp_gl_init(SpObject* w, SpObject* h, SpObject* title) {"
     , "#ifdef __EMSCRIPTEN__"
     , "    SDL_Init(SDL_INIT_VIDEO);"
-    , "    _sp_gl_window = SDL_CreateWindow(title->value.str,"
+    , "    _sp_gl_window = SDL_CreateWindow(title->value.string,"
     , "        SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,"
     , "        (int)w->value.integer, (int)h->value.integer, SDL_WINDOW_OPENGL);"
     , "    _sp_gl_context = SDL_GL_CreateContext(_sp_gl_window);"
     , "#else"
     , "    glfwInit();"
     , "    _sp_gl_window = glfwCreateWindow((int)w->value.integer,"
-    , "        (int)h->value.integer, title->value.str, NULL, NULL);"
+    , "        (int)h->value.integer, title->value.string, NULL, NULL);"
     , "    glfwMakeContextCurrent(_sp_gl_window);"
     , "#endif"
     , "    return sp_make_bool(true);"
@@ -491,9 +512,7 @@ glHelpers = T.unlines
     , ""
     , "SpObject* sp_gl_draw_points(SpObject* data) {"
     , "    (void)data;"
-    , "    glBegin(GL_POINTS);"
-    , "    /* TODO: extract vertex data from SpObject matrix */"
-    , "    glEnd();"
+    , "    /* TODO: implement draw_points with shaders (glBegin/glEnd not available in ES 2.0) */"
     , "    return sp_make_nil();"
     , "}"
     ]


### PR DESCRIPTION
## Summary
- Windows で `build --wasm` 実行時、emcc.bat のサブプロセスが Python を見つけられない問題を修正（`EMSDK_PYTHON` 環境変数を設定）
- C コード生成の `value.str` を `value.string` に修正（ランタイムの SpValue 定義と整合）
- OpenGL ES 2.0 非互換の `glBegin`/`glEnd` を削除
- OpenGL ヘルパーコードを GL 関数使用時のみ出力するように変更
- `System.Process` インポートによる name-shadowing 警告を修正

## Test plan
- [x] `cabal build` が警告なしで成功
- [x] `cabal test` — 254 テスト全て合格
- [x] `cabal run spinor -- build --wasm test-wasm.spin` が WASM ビルド成功
- [x] `cabal run spinor -- build test-wasm.spin` がネイティブビルド成功、実行結果 `120`
- [x] `cabal run spinor -- build-llvm fib-aot.spin` が LLVM ビルド成功、実行結果 `55`

🤖 Generated with [Claude Code](https://claude.com/claude-code)