### PR TITLE
docs: Update build-llvm and build-wasm guides for Windows support

### DIFF
--- a/docs/docs/aot/build-llvm.md
+++ b/docs/docs/aot/build-llvm.md
@@ -7,15 +7,19 @@ LLVM IR を生成し、Clang でネイティブバイナリを生成します。
 
 ```bash
 # LLVM IR 経由でコンパイル
-cabal run spinor -- build-llvm fib.spin
+cabal run spinor -- build-llvm fib-aot.spin
 
 # 生成された実行ファイルを実行
-./fib
+./fib-aot        # Linux / macOS
+.\fib-aot.exe    # Windows
 ```
 
 ## 前提条件
 
-システムに LLVM (Clang) がインストールされている必要があります。
+- LLVM (Clang) がインストールされていること
+- Windows の場合: MSYS2 (MinGW) がインストールされていること（GHCup で自動インストールされます）
+
+> **Windows の補足:** Spinor は Windows 上で clang を呼び出す際に `--target=x86_64-pc-windows-gnu` フラグを自動的に付与します。これにより MSYS2 の MinGW ヘッダーが使用されるため、Visual Studio の Developer Command Prompt は不要です。
 
 ---
 

--- a/docs/docs/aot/build-wasm.md
+++ b/docs/docs/aot/build-wasm.md
@@ -18,7 +18,29 @@ cabal run spinor -- build --wasm app.spin
 
 Emscripten SDK がインストールされている必要があります。
 
-### Emscripten のインストール
+---
+
+## Windows でのインストール
+
+```powershell
+# 1. emsdk のクローン
+git clone https://github.com/emscripten-core/emsdk.git C:\emsdk
+cd C:\emsdk
+
+# 2. Python でインストール・有効化を実行
+#    (emsdk.bat は Python が PATH に必要なため、直接 emsdk.py を呼び出す)
+python emsdk.py install latest
+python emsdk.py activate latest
+
+# 3. 環境変数の設定 (新しいターミナルごとに実行)
+C:\emsdk\emsdk_env.ps1
+```
+
+> **Windows の補足:** Spinor は emcc.bat を呼び出す際に `EMSDK_PYTHON` 環境変数を自動的に設定します。そのため `emsdk_env.ps1` を実行しなくても、emsdk が `C:\emsdk` にインストールされていれば動作します。
+
+---
+
+## Linux / WSL2 でのインストール
 
 ```bash
 # emsdk のクローン
@@ -33,7 +55,26 @@ cd emsdk
 source ./emsdk_env.sh
 ```
 
-### 動作確認
+---
+
+## macOS でのインストール
+
+```bash
+# emsdk のクローン
+git clone https://github.com/emscripten-core/emsdk.git
+cd emsdk
+
+# 最新版のインストールと有効化
+./emsdk install latest
+./emsdk activate latest
+
+# 環境変数の設定
+source ./emsdk_env.sh
+```
+
+---
+
+## 動作確認
 
 ```bash
 emcc --version

--- a/manual/public/docs/aot/build-llvm.md
+++ b/manual/public/docs/aot/build-llvm.md
@@ -7,15 +7,19 @@ LLVM IR を生成し、Clang でネイティブバイナリを生成します。
 
 ```bash
 # LLVM IR 経由でコンパイル
-cabal run spinor -- build-llvm fib.spin
+cabal run spinor -- build-llvm fib-aot.spin
 
 # 生成された実行ファイルを実行
-./fib
+./fib-aot        # Linux / macOS
+.\fib-aot.exe    # Windows
 ```
 
 ## 前提条件
 
-システムに LLVM (Clang) がインストールされている必要があります。
+- LLVM (Clang) がインストールされていること
+- Windows の場合: MSYS2 (MinGW) がインストールされていること（GHCup で自動インストールされます）
+
+> **Windows の補足:** Spinor は Windows 上で clang を呼び出す際に `--target=x86_64-pc-windows-gnu` フラグを自動的に付与します。これにより MSYS2 の MinGW ヘッダーが使用されるため、Visual Studio の Developer Command Prompt は不要です。
 
 ---
 

--- a/manual/public/docs/aot/build-wasm.md
+++ b/manual/public/docs/aot/build-wasm.md
@@ -18,7 +18,29 @@ cabal run spinor -- build --wasm app.spin
 
 Emscripten SDK がインストールされている必要があります。
 
-### Emscripten のインストール
+---
+
+## Windows でのインストール
+
+```powershell
+# 1. emsdk のクローン
+git clone https://github.com/emscripten-core/emsdk.git C:\emsdk
+cd C:\emsdk
+
+# 2. Python でインストール・有効化を実行
+#    (emsdk.bat は Python が PATH に必要なため、直接 emsdk.py を呼び出す)
+python emsdk.py install latest
+python emsdk.py activate latest
+
+# 3. 環境変数の設定 (新しいターミナルごとに実行)
+C:\emsdk\emsdk_env.ps1
+```
+
+> **Windows の補足:** Spinor は emcc.bat を呼び出す際に `EMSDK_PYTHON` 環境変数を自動的に設定します。そのため `emsdk_env.ps1` を実行しなくても、emsdk が `C:\emsdk` にインストールされていれば動作します。
+
+---
+
+## Linux / WSL2 でのインストール
 
 ```bash
 # emsdk のクローン
@@ -33,7 +55,26 @@ cd emsdk
 source ./emsdk_env.sh
 ```
 
-### 動作確認
+---
+
+## macOS でのインストール
+
+```bash
+# emsdk のクローン
+git clone https://github.com/emscripten-core/emsdk.git
+cd emsdk
+
+# 最新版のインストールと有効化
+./emsdk install latest
+./emsdk activate latest
+
+# 環境変数の設定
+source ./emsdk_env.sh
+```
+
+---
+
+## 動作確認
 
 ```bash
 emcc --version


### PR DESCRIPTION
## Summary
- `build-llvm.md`: サンプルファイル名を `fib-aot.spin` に修正、Windows での MinGW ターゲット自動設定と MSYS2 要件の説明を追加
- `build-wasm.md`: Windows / Linux / macOS 別のインストール手順に分離、Windows での Python 問題の対処法と `EMSDK_PYTHON` 自動検出の補足を追加
- `docs/docs/` と `manual/public/docs/` を同期済み

## Test plan
- [x] ドキュメントの内容が実装 (PR #37, #38) と整合していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)