### PR TITLE
feat: add --emit-c flag to build command (Issue #47)

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -61,6 +61,7 @@ helpMessage = unlines
   , "  check <file>           Parse and type-check only (no execution)"
   , "  init <name>            Create a new Spinor project"
   , "  build <file>           Compile to native binary (via C + GCC)"
+  , "  build <file> --emit-c  Emit <basename>.c only, skip GCC (for Unikernel etc.)"
   , "  build <file> --wasm    Compile to WASM (via C + Emscripten)"
   , "  compile <file>         Transpile to C source code only"
   , "  build-llvm <file>      Compile to native binary (via LLVM IR + Clang)"
@@ -91,7 +92,8 @@ main = do
   args <- getArgs
   -- Parse global flags
   let (jsonMode, args1) = parseJsonFlag args
-      (quietMode, restArgs) = parseQuietFlag args1
+      (quietMode, args2) = parseQuietFlag args1
+      (emitCMode, restArgs) = parseEmitCFlag args2
   case restArgs of
     []                  -> replMode quietMode
     ["--help"]          -> putStr helpMessage
@@ -102,7 +104,7 @@ main = do
     ["check", file]     -> checkMode jsonMode file
     ["compile", file]   -> compileMode quietMode file
     ["build-llvm", file] -> buildLlvmMode quietMode file
-    ["build", file]              -> buildMode quietMode file
+    ["build", file]              -> buildMode quietMode emitCMode file
     ["build", file, "--wasm"]    -> buildWasmMode quietMode file
     ["build", "--wasm", file]    -> buildWasmMode quietMode file
     ("server" : rest)   -> serverMode quietMode rest
@@ -120,6 +122,15 @@ parseJsonFlag args = (hasJson, filter (/= "--json") args)
 parseQuietFlag :: [String] -> (Bool, [String])
 parseQuietFlag args = (hasQuiet, filter (`notElem` ["-q", "--quiet"]) args)
   where hasQuiet = "-q" `elem` args || "--quiet" `elem` args
+
+-- | Parse --emit-c flag from arguments
+--
+-- `build` サブコマンドで使用する。指定された場合、C コードのみを生成して
+-- gcc/clang を呼び出さず、`<basename>.c` をカレントディレクトリに出力する。
+-- Unikernel ビルドなど、後段の C ツールチェインへ生成物を引き渡す用途を想定。
+parseEmitCFlag :: [String] -> (Bool, [String])
+parseEmitCFlag args = (hasEmitC, filter (/= "--emit-c") args)
+  where hasEmitC = "--emit-c" `elem` args
 
 -- | サーバーモード: TCP ソケットで REPL サービスを提供
 serverMode :: Bool -> [String] -> IO ()
@@ -400,11 +411,19 @@ findClang = do
       if exists then pure c else findFirst cs
 
 -- | ビルドモード: .spin ファイルからネイティブバイナリを生成
-buildMode :: Bool -> FilePath -> IO ()
-buildMode quiet file = do
+--
+-- `--emit-c` フラグが True の場合は C コード生成のみを行い、
+-- `<basename>.c` をカレントディレクトリに書き出してから gcc 呼び出しをスキップする。
+-- これは Unikraft などの外部 C ツールチェインに生成物を渡すユースケースを想定している。
+buildMode :: Bool -> Bool -> FilePath -> IO ()
+buildMode quiet emitCOnly file = do
   -- 1. パス設定
   let baseName = takeBaseName file
-      cFile = replaceExtension file ".c"
+      -- emit-c モードでは cwd 直下に <basename>.c を出力する。
+      -- 通常モードでは中間ファイルとして元のファイル隣に置き、ビルド成功後に削除する。
+      cFile = if emitCOnly
+              then baseName <> ".c"
+              else replaceExtension file ".c"
       outFile = baseName
       runtimeSrc = "runtime/spinor.c"
 
@@ -419,22 +438,28 @@ buildMode quiet file = do
       let cCode = compileProgram exprs
       TIO.writeFile cFile cCode
 
-      -- 3. Cコンパイラ呼び出し
-      gccPath <- findGcc
-      when (not quiet) $ putStrLn $ "Building " <> outFile <> " with " <> gccPath <> "..."
-      (exitCode, out, err) <- readProcessWithExitCode gccPath ["-Iruntime", "-o", outFile, cFile, runtimeSrc] ""
-      case exitCode of
-        ExitSuccess -> do
-          -- 4. クリーンアップと完了メッセージ
-          doesFileExist cFile >>= \exists ->
-            if exists then removeFile cFile else pure ()
-          when (not quiet) $ putStrLn $ "Build successful. Executable created: " <> outFile
+      if emitCOnly
+        then do
+          -- emit-c モード: gcc 呼び出しをスキップして終了
+          when (not quiet) $ putStrLn $ "C source emitted: " <> cFile
           exitSuccess
-        _ -> do
-          putStrLn "Build failed. C compiler output:"
-          putStrLn out
-          putStrLn err
-          exitFailure
+        else do
+          -- 3. Cコンパイラ呼び出し
+          gccPath <- findGcc
+          when (not quiet) $ putStrLn $ "Building " <> outFile <> " with " <> gccPath <> "..."
+          (exitCode, out, err) <- readProcessWithExitCode gccPath ["-Iruntime", "-o", outFile, cFile, runtimeSrc] ""
+          case exitCode of
+            ExitSuccess -> do
+              -- 4. クリーンアップと完了メッセージ
+              doesFileExist cFile >>= \exists ->
+                if exists then removeFile cFile else pure ()
+              when (not quiet) $ putStrLn $ "Build successful. Executable created: " <> outFile
+              exitSuccess
+            _ -> do
+              putStrLn "Build failed. C compiler output:"
+              putStrLn out
+              putStrLn err
+              exitFailure
 
 -- | gcc を探す (MSYS2 UCRT/MINGW64 対応)
 findGcc :: IO FilePath

--- a/docs/docs/aot/build-c.md
+++ b/docs/docs/aot/build-c.md
@@ -13,6 +13,40 @@ cabal run spinor -- build hello.spin
 ./hello.exe    # Windows
 ```
 
+## `--emit-c`: 中間 C コードのみ生成 (コンパイルをスキップ)
+
+C コードのみを出力し、`gcc` / `clang` の呼び出しをスキップする場合は `--emit-c` フラグを使用します。
+
+```bash
+# hello.spin → hello.c (C ソース) のみを生成 (バイナリは作成されない)
+cabal run spinor -- build --emit-c hello.spin
+# または:
+cabal run spinor -- build hello.spin --emit-c
+```
+
+### 動作の詳細
+
+- 生成された C コードは **カレントディレクトリ** に `<元のファイル名（拡張子なし）>.c` として書き出されます。
+  - 例: `examples/foo.spin --emit-c` → `./foo.c` (`examples/` 配下ではなく cwd 直下)
+- 通常モード (フラグなし) との違い:
+  | 項目 | 通常モード | `--emit-c` モード |
+  |------|----------|-----------------|
+  | C コード生成 | ✅ 行う | ✅ 行う |
+  | 出力先 | 元ファイルの隣 (中間) | cwd 直下 (永続) |
+  | gcc/clang 呼び出し | ✅ 行う | ❌ スキップ |
+  | 中間 C ファイルの削除 | ✅ ビルド成功時に削除 | ❌ 保持 |
+  | 最終成果物 | ネイティブバイナリ | C ソース |
+
+### ユースケース
+
+- **Unikernel ビルド**: [Unikraft](https://unikraft.org/) などの外部 C ツールチェインに生成物を渡し、ベアメタルで動かす Unikernel イメージを構築する場合。詳細は [Unikernel Architecture](../vision/unikernel-architecture.md) を参照。
+- **C コードの検査・デバッグ**: 生成された C を読んで意味論を確認したり、別の C コンパイラ (Tiny C Compiler 等) でビルドしたい場合。
+- **クロスコンパイル**: 生成された C ソースを別環境 (組み込みデバイス、別 OS など) に持っていって現地でビルドする場合。
+
+### 既存の `compile` サブコマンドとの違い
+
+`spinor compile <file>` も C コードのみを出力しますが、出力先が常に `output.c` 固定である点が異なります。`build --emit-c` は元のファイル名を反映した命名規則 (`<basename>.c`) を採用しているため、複数のソースを連続でコンパイルする場合に上書き衝突を避けられます。
+
 ## 前提条件
 
 GCC または Clang がシステムにインストールされている必要があります。

--- a/manual/public/docs/aot/build-c.md
+++ b/manual/public/docs/aot/build-c.md
@@ -13,6 +13,40 @@ cabal run spinor -- build hello.spin
 ./hello.exe    # Windows
 ```
 
+## `--emit-c`: 中間 C コードのみ生成 (コンパイルをスキップ)
+
+C コードのみを出力し、`gcc` / `clang` の呼び出しをスキップする場合は `--emit-c` フラグを使用します。
+
+```bash
+# hello.spin → hello.c (C ソース) のみを生成 (バイナリは作成されない)
+cabal run spinor -- build --emit-c hello.spin
+# または:
+cabal run spinor -- build hello.spin --emit-c
+```
+
+### 動作の詳細
+
+- 生成された C コードは **カレントディレクトリ** に `<元のファイル名（拡張子なし）>.c` として書き出されます。
+  - 例: `examples/foo.spin --emit-c` → `./foo.c` (`examples/` 配下ではなく cwd 直下)
+- 通常モード (フラグなし) との違い:
+  | 項目 | 通常モード | `--emit-c` モード |
+  |------|----------|-----------------|
+  | C コード生成 | ✅ 行う | ✅ 行う |
+  | 出力先 | 元ファイルの隣 (中間) | cwd 直下 (永続) |
+  | gcc/clang 呼び出し | ✅ 行う | ❌ スキップ |
+  | 中間 C ファイルの削除 | ✅ ビルド成功時に削除 | ❌ 保持 |
+  | 最終成果物 | ネイティブバイナリ | C ソース |
+
+### ユースケース
+
+- **Unikernel ビルド**: [Unikraft](https://unikraft.org/) などの外部 C ツールチェインに生成物を渡し、ベアメタルで動かす Unikernel イメージを構築する場合。詳細は [Unikernel Architecture](../vision/unikernel-architecture.md) を参照。
+- **C コードの検査・デバッグ**: 生成された C を読んで意味論を確認したり、別の C コンパイラ (Tiny C Compiler 等) でビルドしたい場合。
+- **クロスコンパイル**: 生成された C ソースを別環境 (組み込みデバイス、別 OS など) に持っていって現地でビルドする場合。
+
+### 既存の `compile` サブコマンドとの違い
+
+`spinor compile <file>` も C コードのみを出力しますが、出力先が常に `output.c` 固定である点が異なります。`build --emit-c` は元のファイル名を反映した命名規則 (`<basename>.c`) を採用しているため、複数のソースを連続でコンパイルする場合に上書き衝突を避けられます。
+
 ## 前提条件
 
 GCC または Clang がシステムにインストールされている必要があります。


### PR DESCRIPTION
## Summary

Issue #47 に基づき、`build` サブコマンドに `--emit-c` フラグを追加。Spinor の AOT C 出力を **gcc/clang を呼ばずに** ファイルとして取り出せるようにし、Unikraft 等の外部 C ツールチェイン (Issue #44 Phase 1 PoC) への受け渡しを可能にします。

## 実装方針

既存の `parseQuietFlag` / `parseJsonFlag` パターンに揃え、グローバル前段で `--emit-c` を抽出してから dispatch する方式を採用。これにより `build hello.spin --emit-c` / `build --emit-c hello.spin` の両記法が自然に通る。

## 変更内容

### `app/Main.hs`

1. **`parseEmitCFlag :: [String] -> (Bool, [String])` 追加** (`parseQuietFlag` と同形)
   ```haskell
   parseEmitCFlag :: [String] -> (Bool, [String])
   parseEmitCFlag args = (hasEmitC, filter (/= \"--emit-c\") args)
     where hasEmitC = \"--emit-c\" `elem` args
   ```

2. **`buildMode` のシグネチャ拡張**: `Bool -> FilePath -> IO ()` → `Bool -> Bool -> FilePath -> IO ()`
   - 第 2 引数 `emitCOnly` が True の場合:
     - 出力ファイル名: `takeBaseName file <> \".c\"` (cwd 直下、`<basename>.c`)
     - gcc 呼び出しをスキップして即 `exitSuccess`
     - 中間ファイル削除も実行しない (永続化)
   - False の場合: 従来動作 (元ファイルの隣に中間 C を作り、gcc 後に削除)

3. **ヘルプメッセージに 1 行追加**

### `docs/aot/build-c.md` (および `manual/public/docs/aot/build-c.md` 同期)

- `--emit-c` の使用方法と動作詳細
- 通常モードとの比較テーブル
- ユースケース (Unikernel ビルド / 検査 / クロスコンパイル)
- 既存 `compile` サブコマンドとの違い (出力先の命名規則)

## 検証

### ⚠️ 環境制約による `cabal build` 未完走

本環境 (MSYS2 ucrt64) には `openblas` が未インストールで、`hmatrix-0.20.2` の configure ステップが失敗します:

\`\`\`
Configuring library for hmatrix-0.20.2...
Error: [Cabal-4345] Missing dependency on a foreign library:
* Missing (or bad) C library: openblas
\`\`\`

これは **pre-existing な環境問題で本変更とは無関係** (`Spinor.Primitive` が hmatrix を要求)。`pacman -S mingw-w64-ucrt-x86_64-openblas` の実行権限が無いため、本セッション内では完全な `cabal build` 完走を確認できません。

### ✅ 引数解析・cFile 計算ロジックの隔離検証

実コードからコピーした関数を `runghc` で実行し、6 ケースで期待通り動作を確認:

| # | 入力 | emitC | 出力 cFile |
|---|------|-------|-----------|
| 1 | `build hello.spin` | False | `hello.c` (元ファイル隣) |
| 2 | `build hello.spin --emit-c` | True | `hello.c` (cwd 直下) |
| 3 | `build --emit-c hello.spin` | True | `hello.c` (cwd 直下) |
| 4 | `build examples/foo.spin --emit-c` | True | `foo.c` (cwd 直下) ⭐ |
| 5 | `build --quiet hello.spin --emit-c` | True (+quiet=True) | (両フラグ独立に動作) |
| 6 | `build examples/foo.spin` | False | `examples/foo.c` (元ファイル隣) |

⭐ Case 4 は要件「カレントディレクトリに書き出す」を満たすことを確認。

## Test plan

レビュアー側で openblas 入りの環境で確認していただきたい項目:

- [ ] `cabal build` がエラーなく完走する
- [ ] `cabal run spinor -- build --emit-c fib-aot.spin` を実行し、cwd 直下に `fib-aot.c` が生成されること
- [ ] 生成された `fib-aot.c` が GCC で手動コンパイルできること: `gcc -Iruntime fib-aot.c runtime/spinor.c -o fib-aot && ./fib-aot`
- [ ] フラグ無しの `cabal run spinor -- build fib-aot.spin` が従来どおり動作すること (regression なし)
- [ ] `cabal run spinor -- build hello.spin --emit-c` (フラグ末尾) も動作すること
- [ ] `cabal run spinor -- --help` のヘルプに `--emit-c` の行が表示されること

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)