### PR TITLE
fix: prevent user_ prefix mangling on `print` primitive (Issue #50)

### DIFF
--- a/examples/hello.spin
+++ b/examples/hello.spin
@@ -1,0 +1,9 @@
+; examples/hello.spin - Smoke test for the AOT codegen primitive fix (Issue #50)
+;
+; Usage:
+;   cabal run spinor -- build --emit-c examples/hello.spin   # Cコードのみ
+;   cabal run spinor -- build examples/hello.spin            # ネイティブビルド
+;   ./hello                                                  # 実行
+;
+; Expected output: Hello, World!
+(print "Hello, World!")

--- a/runtime/spinor.c
+++ b/runtime/spinor.c
@@ -224,10 +224,10 @@ SpObject* sp_file_exists(SpObject* path) {
 
 /* ========== ユーティリティ ========== */
 
-void sp_print(SpObject* obj) {
+SpObject* sp_print(SpObject* obj) {
     if (!obj) {
         printf("NULL\n");
-        return;
+        return obj;
     }
     switch (obj->type) {
         case SP_NIL:
@@ -246,4 +246,5 @@ void sp_print(SpObject* obj) {
             printf("<unknown>\n");
             break;
     }
+    return obj;  /* Lisp 伝統: print は引数をそのまま返す */
 }

--- a/runtime/spinor.h
+++ b/runtime/spinor.h
@@ -84,7 +84,9 @@ SpObject* sp_file_exists(SpObject* path);
 
 /* ========== ユーティリティ ========== */
 
-void sp_print(SpObject* obj);
+/* sp_print: 値を表示し、引数 obj をそのまま返す (Lisp 伝統に倣う)。
+ * 戻り値を SpObject* にしたことで、(print x) を式コンテキストでも使える。 */
+SpObject* sp_print(SpObject* obj);
 const char* sp_format(SpObject* obj);
 
 /* ========== 旧 API との互換性 (エイリアス) ========== */

--- a/src/Spinor/Compiler/Codegen.hs
+++ b/src/Spinor/Compiler/Codegen.hs
@@ -332,7 +332,13 @@ mangle name = "user_" <> T.map sanitize name
 -- | トップレベル式を C のステートメントに変換
 --
 -- 式を評価し、その結果を sp_print で表示する。
+-- ただし `(print x)` のような副作用プリミティブが直接トップレベルにある場合は
+-- 二重出力を避けるため、外側ラップを省略してプリミティブ呼び出しのみ生成する。
 compileStmt :: Expr -> CCode
+-- `(print x)` を top-level に書いた場合: 外側の sp_print 自動ラップをスキップ
+-- (compileExpr が `sp_print(...)` を生成するため、二重出力を防ぐ)
+compileStmt expr@(EList _ [ESym _ "print", _]) =
+    "    " <> compileExpr expr <> ";"
 compileStmt expr =
     let valCode = compileExpr expr
     in "    sp_print(" <> valCode <> ");"
@@ -393,6 +399,13 @@ compileExpr (EList _ [ESym _ "append-file", path, content]) =
 compileExpr (EList _ [ESym _ "file-exists?", path]) =
     "sp_file_exists(" <> compileExpr path <> ")"
 
+-- 出力プリミティブ
+-- `print` は runtime/spinor.h の sp_print に直接マッピングする (mangle 経由しない)。
+-- sp_print は SpObject* を返す (Lisp 伝統: print は引数をそのまま返す) ので
+-- 式コンテキストでも安全に使える。
+compileExpr (EList _ [ESym _ "print", x]) =
+    "sp_print(" <> compileExpr x <> ")"
+
 -- OpenGL プリミティブ
 compileExpr (EList _ [ESym _ "gl-init", w, h, title]) =
     "sp_gl_init(" <> compileExpr w <> ", " <> compileExpr h <> ", " <> compileExpr title <> ")"
@@ -430,6 +443,7 @@ compileExpr (EList _ (ESym _ fname : args))
         in cFun <> "(" <> cArgs <> ")"
   where
     primitives = ["+", "-", "*", "/", "=", "<", ">", "<=", ">=", "if", "defun",
+                  "print",
                   "string-append", "string-length", "substring", "string=?",
                   "read-file", "write-file", "append-file", "file-exists?",
                   "gl-init", "gl-clear", "gl-draw-points",


### PR DESCRIPTION
## Summary

Issue #50 の修正。AOT C コードジェネレータが `(print x)` を `user_print(...)` にマングルしていた pre-existing バグを修正し、`runtime/spinor.h` の `sp_print` に正しくマッピングするように変更しました。

## 原因分析

`src/Spinor/Compiler/Codegen.hs` の **3 箇所** が連動して問題を起こしていました:

1. **`compileExpr` の関数呼び出し fallback (line 426-436)**: `(print x)` が primitives リストに無いため、user-defined function 扱いで `mangle` → `user_print(...)` が生成される。
2. **`runtime/spinor.h:87` の `sp_print` シグネチャ**: 戻り値が `void` のため、たとえ `print` → `sp_print` マッピングを追加しても、`compileStmt` の自動ラップ (line 336) との合成で `sp_print(sp_print(...))` という型エラーになる。
3. **`compileStmt` の自動 sp_print ラップ**: 全トップレベル式を `sp_print(...)` で囲むため、`(print x)` を素直にマッピングすると二重出力になる。

3 つを同時に対応しなければ、gcc を通り、なおかつ意味論的に正しい (二重出力しない) コードは生成できません。

## 変更内容

### `src/Spinor/Compiler/Codegen.hs`

1. **`compileExpr` に `(print x)` の専用パターンを追加** (line 397-399):
   ```haskell
   compileExpr (EList _ [ESym _ "print", x]) =
       "sp_print(" <> compileExpr x <> ")"
   ```
   `mangle` 経路をバイパスして `sp_print(...)` を直接生成。

2. **`primitives` リストに `"print"` を追加** (line 432 付近、防御的措置):
   上記の専用パターンで先に捕まるが、fallback でも mangling されないよう明示。

3. **`compileStmt` で `(print x)` を特別扱い**:
   ```haskell
   compileStmt expr@(EList _ [ESym _ "print", _]) =
       "    " <> compileExpr expr <> ";"
   ```
   トップレベル `(print x)` で外側の自動 `sp_print(...)` ラップをスキップし、二重出力を防ぐ。

### `runtime/spinor.h` & `runtime/spinor.c`

`sp_print` のシグネチャを **`void` → `SpObject*`** に変更し、引数 `obj` をそのまま返すよう実装 (Lisp 伝統の `print` セマンティクス):

```c
SpObject* sp_print(SpObject* obj) {
    // ... 既存の出力処理 ...
    return obj;  /* Lisp 伝統: print は引数をそのまま返す */
}
```

これにより `sp_print` が式コンテキストで合成可能 (`(begin (print "a") (print "b"))` などにも対応可能) になります。既存の `sp_print(...)` を statement として呼んでいる箇所は戻り値が discard されるだけで挙動に影響なし。

### `examples/hello.spin` (新規)

最小スモークテスト用ファイル:
```lisp
(print "Hello, World!")
```

## 検証結果

### Test 1: `--emit-c` での C コード確認

\`\`\`
$ cabal run spinor -- build --emit-c examples/hello.spin
Compiling examples/hello.spin to hello.c...
C source emitted: hello.c
\`\`\`

生成された `hello.c`:
```c
#include <stdio.h>
#include <stdbool.h>
#include "spinor.h"

int main(void) {
    sp_print(sp_make_str("Hello, World!"));
    return 0;
}
```

- ✅ `user_print` 完全排除 (`grep user_print hello.c` → 0 件)
- ✅ `sp_print` 呼び出しは 1 回のみ (二重ラップなし)
- ✅ `sp_make_str` で文字列を生成して `sp_print` に渡す正しい構造

### Test 2: 通常ビルド + 実行

\`\`\`
$ cabal run spinor -- build examples/hello.spin
Compiling examples/hello.spin to examples/hello.c...
Building hello with C:\msys64\ucrt64\bin\gcc.exe...
Build successful. Executable created: hello

$ ./hello.exe
Hello, World!
\`\`\`

- ✅ gcc コンパイル成功 (Issue 報告のエラーが解消)
- ✅ `hello.exe` (145,600 bytes) 生成
- ✅ 実行で `Hello, World!` を **1 回だけ** 出力 (二重出力なし)

### Test 3: Regression — `test-tco.spin`

\`\`\`
$ cabal run spinor -- build test-tco.spin && ./test-tco.exe
Build successful. Executable created: test-tco
0
\`\`\`

- ✅ TCO 機能 (1M iter countdown) 引き続き動作
- ✅ `print` を含まないトップレベル式の自動 `sp_print` 表示も従来通り

## Test plan

- [ ] `cabal build` がエラーなく完走
- [ ] `cabal run spinor -- build --emit-c examples/hello.spin` が `sp_print(sp_make_str("Hello, World!"))` を含む `hello.c` を生成 (`user_print` を含まない)
- [ ] `cabal run spinor -- build examples/hello.spin && ./hello.exe` が `Hello, World!` を 1 回出力
- [ ] `test-tco.spin` の regression 無し
- [ ] `fib-aot.spin` 等の他 AOT サンプルが引き続きビルド可能

## 関連

- Issue #50 (本 PR で Closes)
- Issue #47 (#49 で実装した `--emit-c` を使って検証)
- Issue #44 (Unikernel 化の Phase 1 PoC でこの修正が前提)

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)