### PR TITLE
ci: add Spinor OS automated build pipeline (Issue #54)

### DIFF
--- a/.github/workflows/os-build.yml
+++ b/.github/workflows/os-build.yml
@@ -84,7 +84,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libgsl-dev \
-            libblas-dev \
+            libopenblas-dev \
             liblapack-dev \
             libgl1-mesa-dev \
             libglu1-mesa-dev \

--- a/.github/workflows/os-build.yml
+++ b/.github/workflows/os-build.yml
@@ -70,17 +70,24 @@ jobs:
             ${{ runner.os }}-cabal-
 
       # ---------------------------------------------------------------------
-      # 4. hmatrix が依存する BLAS / LAPACK / GSL をシステムにインストール。
-      #    (release.yml の Linux ジョブには無いが、ubuntu-latest の前提環境が
-      #    変化したときに失敗するのを避けるため明示的に入れる)
+      # 4. Spinor が依存するシステムライブラリのインストール。
+      #    - hmatrix: libgsl-dev / libblas-dev / liblapack-dev
+      #    - OpenGLRaw / OpenGL: libgl1-mesa-dev (GL), libglu1-mesa-dev (GLU)
+      #    - GLFW-b: libglfw3-dev
+      #    (CI 上の ubuntu-latest にはこれらの -dev パッケージが入っていない
+      #    ため、明示的にインストールする必要がある)
       # ---------------------------------------------------------------------
-      - name: Install system dependencies for hmatrix
+      - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libgsl-dev \
             libblas-dev \
-            liblapack-dev
+            liblapack-dev \
+            libgl1-mesa-dev \
+            libglu1-mesa-dev \
+            libglfw3-dev \
+            pkg-config
 
       # ---------------------------------------------------------------------
       # 5. Spinor コンパイラのビルド

--- a/.github/workflows/os-build.yml
+++ b/.github/workflows/os-build.yml
@@ -71,13 +71,15 @@ jobs:
 
       # ---------------------------------------------------------------------
       # 4. Spinor が依存するシステムライブラリのインストール。
-      #    - hmatrix: libgsl-dev / libblas-dev / liblapack-dev
+      #    - hmatrix: libgsl-dev / libopenblas-dev / liblapack-dev
+      #      (cabal.project.local で +openblas フラグが有効なため openblas 必須)
       #    - OpenGLRaw / OpenGL: libgl1-mesa-dev (GL), libglu1-mesa-dev (GLU)
       #    - GLFW-b / bindings-GLFW: libglfw3-dev + X11 系
       #      (Xi / Xrandr / Xxf86vm / Xcursor / Xinerama を GLFW がリンク要求)
+      #    - Spinor.GPGPU: ocl-icd-opencl-dev (OpenCL ICD loader)
       #    (CI 上の ubuntu-latest にはこれらの -dev パッケージが入っていない
       #    ため、明示的にインストールする必要がある。ヘッドレス環境でも
-      #    リンク時には X11 ヘッダが必要)
+      #    リンク時には X11 ヘッダ等が必要)
       # ---------------------------------------------------------------------
       - name: Install system dependencies
         run: |
@@ -94,6 +96,7 @@ jobs:
             libxxf86vm-dev \
             libxcursor-dev \
             libxinerama-dev \
+            ocl-icd-opencl-dev \
             pkg-config
 
       # ---------------------------------------------------------------------

--- a/.github/workflows/os-build.yml
+++ b/.github/workflows/os-build.yml
@@ -144,14 +144,25 @@ jobs:
         run: ls -la os/
 
       # ---------------------------------------------------------------------
-      # 8. Unikraft で Unikernel をビルド
-      #    --no-update: 対話プロンプトとリモートからのテンプレート更新を抑制
+      # 8. Unikraft パッケージマニフェストの初期化
+      #    クリーンな CI 環境では kraftkit のローカル manifest キャッシュが
+      #    空のため、`kraft pkg update` で Unikraft の公式コンポーネント
+      #    (core/unikraft、lib/musl 等) のメタデータを取得しないと `kraft
+      #    build` が "could not find: core/unikraft:stable" で失敗する。
+      # ---------------------------------------------------------------------
+      - name: Update kraftkit manifests
+        run: kraft pkg update
+
+      # ---------------------------------------------------------------------
+      # 9. Unikraft で Unikernel をビルド
       #    --log-level info: ログ出力を控えめに
+      #    (--no-update は付けない。初回ビルドでは Unikraft コアと libs を
+      #    取得する必要があるため、kraftkit に自動 fetch させる)
       # ---------------------------------------------------------------------
       - name: Build Unikernel
         working-directory: os
         run: |
-          kraft build --no-update --log-level info
+          kraft build --log-level info
 
       - name: Show build output
         if: always()

--- a/.github/workflows/os-build.yml
+++ b/.github/workflows/os-build.yml
@@ -73,9 +73,11 @@ jobs:
       # 4. Spinor が依存するシステムライブラリのインストール。
       #    - hmatrix: libgsl-dev / libblas-dev / liblapack-dev
       #    - OpenGLRaw / OpenGL: libgl1-mesa-dev (GL), libglu1-mesa-dev (GLU)
-      #    - GLFW-b: libglfw3-dev
+      #    - GLFW-b / bindings-GLFW: libglfw3-dev + X11 系
+      #      (Xi / Xrandr / Xxf86vm / Xcursor / Xinerama を GLFW がリンク要求)
       #    (CI 上の ubuntu-latest にはこれらの -dev パッケージが入っていない
-      #    ため、明示的にインストールする必要がある)
+      #    ため、明示的にインストールする必要がある。ヘッドレス環境でも
+      #    リンク時には X11 ヘッダが必要)
       # ---------------------------------------------------------------------
       - name: Install system dependencies
         run: |
@@ -87,6 +89,11 @@ jobs:
             libgl1-mesa-dev \
             libglu1-mesa-dev \
             libglfw3-dev \
+            libxi-dev \
+            libxrandr-dev \
+            libxxf86vm-dev \
+            libxcursor-dev \
+            libxinerama-dev \
             pkg-config
 
       # ---------------------------------------------------------------------

--- a/.github/workflows/os-build.yml
+++ b/.github/workflows/os-build.yml
@@ -1,0 +1,154 @@
+# Build Spinor OS — Phase 1 PoC の Unikernel ビルドを CI で自動化する
+#
+# Issue #54 / The Ultimate Dream の Phase 1。
+# クリーンな Ubuntu 環境で以下を再現可能に実行し、生成された Unikernel
+# イメージを Artifact として保存する:
+#   1. Haskell (GHC + Cabal) で Spinor コンパイラをビルド
+#   2. ./build-os.sh で examples/hello.spin → C コードを抽出して os/ を準備
+#   3. cd os && kraft build で Unikraft Unikernel イメージを生成
+#
+# 関連:
+#   - Issue #47 (--emit-c フラグ)
+#   - Issue #50 (codegen の print プリミティブ修正)
+#   - Issue #52 (os/ ビルド環境テンプレート)
+#   - docs/vision/unikernel-architecture.md
+
+name: Build Spinor OS
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+# 同一 PR / branch への連続 push 時に古い run をキャンセルして時間とコストを節約。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-os:
+    name: Build Unikernel on Ubuntu
+    runs-on: ubuntu-latest
+
+    env:
+      # kraftkit の対話プロンプト・テレメトリ・自動更新確認を抑制
+      KRAFTKIT_NO_CHECK_UPDATES: "true"
+      KRAFTKIT_LOG_LEVEL: info
+      KRAFTKIT_NO_WARNINGS: "true"
+
+    steps:
+      # ---------------------------------------------------------------------
+      # 1. Checkout
+      # ---------------------------------------------------------------------
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # ---------------------------------------------------------------------
+      # 2. Haskell (GHC + Cabal) のセットアップ
+      #    release.yml と同じバージョンに揃え、キャッシュキーの一貫性を保つ。
+      # ---------------------------------------------------------------------
+      - name: Setup Haskell
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: '9.6.3'
+          cabal-version: 'latest'
+
+      # ---------------------------------------------------------------------
+      # 3. Cabal の依存関係キャッシュ
+      #    spinor.cabal のハッシュをキーにして、依存ビルドを跨ぎで再利用。
+      # ---------------------------------------------------------------------
+      - name: Cache Cabal dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-cabal-${{ hashFiles('**/*.cabal') }}
+          restore-keys: |
+            ${{ runner.os }}-cabal-
+
+      # ---------------------------------------------------------------------
+      # 4. hmatrix が依存する BLAS / LAPACK / GSL をシステムにインストール。
+      #    (release.yml の Linux ジョブには無いが、ubuntu-latest の前提環境が
+      #    変化したときに失敗するのを避けるため明示的に入れる)
+      # ---------------------------------------------------------------------
+      - name: Install system dependencies for hmatrix
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libgsl-dev \
+            libblas-dev \
+            liblapack-dev
+
+      # ---------------------------------------------------------------------
+      # 5. Spinor コンパイラのビルド
+      # ---------------------------------------------------------------------
+      - name: Build Spinor compiler
+        run: |
+          cabal update
+          cabal build exe:spinor
+
+      # ---------------------------------------------------------------------
+      # 6. kraftkit (Unikraft toolchain) のインストール
+      #    公式インストールスクリプトを使用。インストール先 (デフォルト:
+      #    /usr/local/bin) を PATH に確実に通す。
+      # ---------------------------------------------------------------------
+      - name: Install KraftKit
+        run: |
+          curl -sSf https://get.kraftkit.sh | sh
+          # インストール先候補を PATH に追加 (どちらに入っても OK)
+          echo "/usr/local/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Verify kraft installation
+        run: |
+          which kraft || (echo "kraft not found in PATH" >&2; exit 1)
+          kraft version
+
+      # ---------------------------------------------------------------------
+      # 7. AOT で hello.c を生成し os/ を準備
+      # ---------------------------------------------------------------------
+      - name: Generate OS sources
+        run: |
+          chmod +x ./build-os.sh
+          ./build-os.sh
+
+      - name: Show prepared os/ contents
+        run: ls -la os/
+
+      # ---------------------------------------------------------------------
+      # 8. Unikraft で Unikernel をビルド
+      #    --no-update: 対話プロンプトとリモートからのテンプレート更新を抑制
+      #    --log-level info: ログ出力を控えめに
+      # ---------------------------------------------------------------------
+      - name: Build Unikernel
+        working-directory: os
+        run: |
+          kraft build --no-update --log-level info
+
+      - name: Show build output
+        if: always()
+        working-directory: os
+        run: |
+          echo "=== .unikraft/build/ 内容 ==="
+          ls -la .unikraft/build/ 2>/dev/null || echo "(build dir not found)"
+          echo ""
+          echo "=== カーネル候補 ==="
+          find .unikraft/build/ -maxdepth 2 -type f \( -name "*qemu*" -o -name "spinor-os*" \) 2>/dev/null || true
+
+      # ---------------------------------------------------------------------
+      # 9. Artifact のアップロード
+      #    os/.unikraft/build/ 配下の x86_64/qemu 向けカーネルバイナリと
+      #    関連ファイル (デバッグシンボル等) をまとめてアップロード。
+      # ---------------------------------------------------------------------
+      - name: Upload Unikernel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: spinor-os-kernel
+          path: |
+            os/.unikraft/build/spinor-os_qemu-x86_64*
+            os/.unikraft/build/*_qemu-x86_64*
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/os-build.yml
+++ b/.github/workflows/os-build.yml
@@ -109,13 +109,20 @@ jobs:
 
       # ---------------------------------------------------------------------
       # 6. kraftkit (Unikraft toolchain) のインストール
-      #    公式インストールスクリプトを使用。インストール先 (デフォルト:
-      #    /usr/local/bin) を PATH に確実に通す。
+      #    公式インストールスクリプト (get.kraftkit.sh) を使用するが、
+      #    Debian/Ubuntu 経路では apt 操作 (gpg key の /etc/apt/keyrings への
+      #    配置、apt-get install) が走るため root 権限が必須。
+      #    `curl | sh` だと user 権限で走り gpg 書き込みが Permission denied
+      #    になるため、`sudo sh` 経由でパイプして root 権限を最初から渡す。
+      #    また CI は非対話 (/dev/tty 不在) のため、インストーラはデフォルト
+      #    "Y" を採用して apt 経路で kraftkit パッケージを導入する。
       # ---------------------------------------------------------------------
       - name: Install KraftKit
         run: |
-          curl -sSf https://get.kraftkit.sh | sh
-          # インストール先候補を PATH に追加 (どちらに入っても OK)
+          curl -sSf https://get.kraftkit.sh | sudo sh
+          # インストール先候補を PATH に追加 (apt 経路の kraftkit は
+          # /usr/bin/kraft、tarball 経路は /usr/local/bin/kraft、フォール
+          # バック先 $HOME/.local/bin にも対応)
           echo "/usr/local/bin" >> "$GITHUB_PATH"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/os-build.yml
+++ b/.github/workflows/os-build.yml
@@ -109,22 +109,23 @@ jobs:
 
       # ---------------------------------------------------------------------
       # 6. kraftkit (Unikraft toolchain) のインストール
-      #    公式インストールスクリプト (get.kraftkit.sh) を使用するが、
-      #    Debian/Ubuntu 経路では apt 操作 (gpg key の /etc/apt/keyrings への
-      #    配置、apt-get install) が走るため root 権限が必須。
-      #    `curl | sh` だと user 権限で走り gpg 書き込みが Permission denied
-      #    になるため、`sudo sh` 経由でパイプして root 権限を最初から渡す。
-      #    また CI は非対話 (/dev/tty 不在) のため、インストーラはデフォルト
-      #    "Y" を採用して apt 経路で kraftkit パッケージを導入する。
+      #    公式の apt リポジトリ (deb.pkg.kraftkit.sh) から直接導入する。
+      #    `curl ... | sudo sh` (get.kraftkit.sh) は CI 環境では非対話プロ
+      #    ンプト ("What shell are you using?" 等) で無限ループする既知の
+      #    挙動があるため、インストーラを経由せず apt の処理だけ手動で
+      #    実行する。これは get.kraftkit.sh が Debian/Ubuntu 経路で内部
+      #    的に実施しているのと同じ手順 (gpg key 配置 → sources.list 追加
+      #    → apt-get install)。
       # ---------------------------------------------------------------------
       - name: Install KraftKit
         run: |
-          curl -sSf https://get.kraftkit.sh | sudo sh
-          # インストール先候補を PATH に追加 (apt 経路の kraftkit は
-          # /usr/bin/kraft、tarball 経路は /usr/local/bin/kraft、フォール
-          # バック先 $HOME/.local/bin にも対応)
-          echo "/usr/local/bin" >> "$GITHUB_PATH"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          sudo mkdir -p /etc/apt/keyrings
+          curl -fsSL https://deb.pkg.kraftkit.sh/gpg.key \
+            | sudo gpg --dearmor -o /etc/apt/keyrings/unikraft.gpg
+          echo "deb [signed-by=/etc/apt/keyrings/unikraft.gpg] https://deb.pkg.kraftkit.sh /" \
+            | sudo tee /etc/apt/sources.list.d/kraftkit.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y kraftkit
 
       - name: Verify kraft installation
         run: |


### PR DESCRIPTION
## Summary

Issue #54 に基づき、Spinor OS (Unikernel) のビルドが **クリーンな Ubuntu 環境で再現可能** であることを GitHub Actions で自動検証する CI ワークフローを追加します。

### ワークフロー仕様

| 項目 | 値 |
|---|---|
| **Name** | `Build Spinor OS` |
| **Trigger** | `push` (main / master) + `pull_request` |
| **Runner** | `ubuntu-latest` |
| **Concurrency** | 同一 `ref` への連続 push で古い run をキャンセル |

### ステップ構成 (全 12 step)

| # | ステップ | アクション / コマンド |
|---|---------|---------------------|
| 1 | Checkout | `actions/checkout@v4` |
| 2 | Setup Haskell | `haskell-actions/setup@v2` (GHC 9.6.3 + Cabal latest) |
| 3 | Cache Cabal | `actions/cache@v4` (`~/.cabal/store` + `dist-newstyle`) |
| 4 | apt install | `libgsl-dev libblas-dev liblapack-dev` (hmatrix 用) |
| 5 | Build Spinor | `cabal update && cabal build exe:spinor` |
| 6 | Install KraftKit | `curl -sSf https://get.kraftkit.sh \| sh` + `GITHUB_PATH` 追記 |
| 7 | Verify kraft | `kraft version` |
| 8 | Generate OS sources | `chmod +x ./build-os.sh && ./build-os.sh` |
| 9 | Show os/ | `ls -la os/` |
| 10 | Build Unikernel | `cd os && kraft build --no-update --log-level info` |
| 11 | Show build output | 失敗時もデバッグ用に `.unikraft/build/` をダンプ (`if: always()`) |
| 12 | Upload Artifact | `actions/upload-artifact@v4` 名前: `spinor-os-kernel` |

## 設計判断

### Haskell 環境
`release.yml` と同じ **GHC 9.6.3 / Cabal latest** に揃え、キャッシュキー (`hashFiles('**/*.cabal')`) も同形にして同 PR・branch 間でのキャッシュ共有可能性を高めています。

### hmatrix の追加システム依存
`release.yml` の Linux ジョブには無いが、`spinor.cabal` の `hmatrix >= 0.20` が **libgsl / BLAS / LAPACK** を要求するため、明示的に `apt install libgsl-dev libblas-dev liblapack-dev` を追加。ubuntu-latest のプリインストールに頼らず堅牢化。

### KraftKit の対話プロンプト抑制
CI 環境で `kraft` が対話プロンプトを出さないように 2 段構えで対策:

1. **env で設定**:
   - `KRAFTKIT_NO_CHECK_UPDATES=true` — 自動更新確認をスキップ
   - `KRAFTKIT_LOG_LEVEL=info` — 過剰なログを抑制
   - `KRAFTKIT_NO_WARNINGS=true` — 警告非表示
2. **`kraft build` フラグ**: `--no-update` でリモートからのテンプレート更新を抑制

### PATH 設定
`get.kraftkit.sh` のデフォルト install 先 (`/usr/local/bin`) と fallback (`~/.local/bin`) の両方を `GITHUB_PATH` に追加。`which kraft || exit 1` で実装上の検出も確実に。

### Artifact パス
Unikraft の出力命名規則 (`<name>_<plat>-<arch>`) に従い、`os/.unikraft/build/spinor-os_qemu-x86_64*` をグロブ。デバッグシンボル (`.dbg`) なども含めて upload。`if-no-files-found: error` で「成功扱いだが Artifact 空」の silent failure を防ぐ。

## 検証

`npm` の `yaml` パッケージで構文解析を実施し、以下を確認:

\`\`\`
YAML PARSE OK
name: Build Spinor OS
jobs: build-os
steps: 12
triggers: push,pull_request
runs-on: ubuntu-latest
  [1] Checkout repository
  [2] Setup Haskell
  [3] Cache Cabal dependencies
  [4] Install system dependencies for hmatrix
  [5] Build Spinor compiler
  [6] Install KraftKit
  [7] Verify kraft installation
  [8] Generate OS sources
  [9] Show prepared os/ contents
  [10] Build Unikernel
  [11] Show build output
  [12] Upload Unikernel artifact
\`\`\`

- ✅ 必須トップレベルキー (`name`, `on`, `jobs`) 揃い
- ✅ Issue 要件 (Checkout / Haskell / Cache / KraftKit / Generate / Build / Upload) を全てカバー
- ✅ インデントは spaces only (タブ無し)

## Test plan

本 PR がマージ (もしくは PR 上で run) されると初回実行されます。レビュー時に確認していただきたい項目:

- [ ] PR push で `Build Spinor OS` workflow が起動する
- [ ] `cabal build` ステップが kabal cache hit で短縮される (初回はフルビルド)
- [ ] `kraft version` が正しく表示される
- [ ] `./build-os.sh` が `os/hello.c` 等を正しく生成する
- [ ] `kraft build` が完走し `.unikraft/build/` 配下にバイナリが生成される
- [ ] Artifact `spinor-os-kernel` がダウンロード可能になる

初回はキャッシュ無し + Unikraft 初期化があるため 10〜20 分程度かかる見込み。2 回目以降はキャッシュヒットで大幅短縮されるはず。

## 既知の懸念

- **`kraft build` 初回の Unikraft コアダウンロード時間**: 数百 MB の Unikraft ソースを取得するため初回は時間がかかります。本ワークフローではキャッシュしていません (`.unikraft/` を `os/` 配下にローカルクローン)。
- **Artifact パスの未確定要素**: Unikraft のバージョンによっては出力ファイル名が変わる可能性があります。`*_qemu-x86_64*` のグロブで吸収を試みていますが、CI 失敗時に Step 11 のダンプで実体を確認し、必要なら glob を調整します。

## 関連

- Issue #44 (Unikernel 化アーキテクチャ調査)
- Issue #47 (`--emit-c` フラグ実装)
- Issue #50 (codegen の `print` プリミティブ修正)
- Issue #52 (`os/` ビルド環境テンプレート) — 本ワークフローの前提
- [docs/vision/unikernel-architecture.md](https://github.com/yanqirenshi/Spinor/blob/master/docs/docs/vision/unikernel-architecture.md)

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)